### PR TITLE
Update for compatability with Laravel 5.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     },
     "require": {
         "php": ">=5.4.0",
-        "laravel/framework": "~5.1"
+        "laravel/framework": "~5.2"
     },
     "require-dev": {
         "mockery/mockery": "0.9.*",

--- a/src/Integration/Laravel/ServiceProvider.php
+++ b/src/Integration/Laravel/ServiceProvider.php
@@ -18,7 +18,7 @@ class ServiceProvider extends BaseProvider {
 
     private function bindInstance()
     {
-        $this->app->bindShared('castle', function(){
+        $this->app->singleton('castle', function(){
             $config = $this->app['config']->get(self::packageKey);
 
             return new Castle($config);


### PR DESCRIPTION
See the deprecations part of the [upgrade guide](https://laravel.com/docs/5.2/upgrade#upgrade-5.1.11). The `bindShared()` has been renamed to `singleton()` in Laravel 5.2
